### PR TITLE
test: Add extensive bats tests

### DIFF
--- a/test/bin/gh
+++ b/test/bin/gh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+cmd="$1"; shift || true
+case "$cmd" in
+  auth)
+    [[ "$1" == "status" ]] && exit 0
+    ;;
+  pr)
+    sub="$1"; shift || true
+    case "$sub" in
+      view)
+        pr="$1"
+        if [[ "$pr" == "1" ]]; then
+          echo "Bump dep from 0.1.0 to 0.1.1"
+        elif [[ "$pr" == "3" ]]; then
+          echo "Bump dep from 0.1.0 to 0.1.1"
+        else
+          echo "Update docs"
+        fi
+        ;;
+      checks)
+        pr="$1"
+        if [[ "$pr" == "1" ]]; then
+          echo "✔ CI"
+        elif [[ "$pr" == "3" ]]; then
+          echo "✖ CI"
+        else
+          echo "✔ CI"
+        fi
+        ;;
+      review|merge)
+        exit 0
+        ;;
+    esac
+    ;;
+  *)
+    ;;
+esac
+exit 0

--- a/test/smoke.bats
+++ b/test/smoke.bats
@@ -1,5 +1,40 @@
 #!/usr/bin/env bats
+
+setup() {
+  PATH="$BATS_TEST_DIRNAME/bin:$PATH"
+}
+
 @test "prints help" {
   run $BATS_TEST_DIRNAME/../gh-pr-approve-and-auto-merge --help
   [ "$status" -eq 0 ]
+}
+
+@test "fails without PR numbers" {
+  run $BATS_TEST_DIRNAME/../gh-pr-approve-and-auto-merge <<<"Y"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No PR numbers supplied."* ]]
+}
+
+@test "dry-run merges dependency bump" {
+  run bash -c "printf 'Y\n' | $BATS_TEST_DIRNAME/../gh-pr-approve-and-auto-merge 1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would approve & merge #1"* ]]
+}
+
+@test "skips non-bump PR" {
+  run bash -c "printf 'Y\n' | $BATS_TEST_DIRNAME/../gh-pr-approve-and-auto-merge 2"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Not a dependency bump"* ]]
+}
+
+@test "skips when CI not green" {
+  run bash -c "printf 'Y\n' | $BATS_TEST_DIRNAME/../gh-pr-approve-and-auto-merge 3"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CI not green"* ]]
+}
+
+@test "handles comma-separated list" {
+  run bash -c "printf 'Y\n' | $BATS_TEST_DIRNAME/../gh-pr-approve-and-auto-merge 1,2"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Will process PRs: 1 2"* ]]
 }


### PR DESCRIPTION
## Summary
- expand test coverage with multiple Bats tests
- add `test/bin/gh` stub to emulate the `gh` CLI for the tests

## Testing
- `npx bats test/`