### PR TITLE
fix: handle log directory and invalid PR numbers

### DIFF
--- a/gh-pr-approve-and-auto-merge
+++ b/gh-pr-approve-and-auto-merge
@@ -39,6 +39,8 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+mkdir -p "$(dirname "$LOG_FILE")"
+
 if [[ ${#PR_ARGS[@]} -eq 0 ]]; then
   echo "❌  No PR numbers supplied."
   _usage
@@ -66,6 +68,10 @@ fi
 
 # ───────── core logic (simplified) ────
 for pr in "${PR_LIST[@]}"; do
+  if [[ ! "$pr" =~ ^[0-9]+$ ]]; then
+    echo "⚠️   Invalid PR number '$pr' – skipping."
+    continue
+  fi
   echo "———  PR #$pr  ———"
   title=$(gh pr view "$pr" --json title --jq '.title' 2>/dev/null || echo "")
   echo "📝  title: $title"

--- a/test/options.bats
+++ b/test/options.bats
@@ -61,3 +61,19 @@ SH
   [[ "$output" == *"CI not green"* ]]
   ! grep -q "pr merge" "$GH_STUB_LOG"
 }
+
+@test "warns and skips invalid PR numbers" {
+  run $BATS_TEST_DIRNAME/../gh-pr-approve-and-auto-merge 1a2b --run --yes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Invalid PR number"* ]]
+  ! grep -q "pr view" "$GH_STUB_LOG"
+}
+
+@test "creates log directory" {
+  logdir="$BATS_TEST_TMPDIR/sub/dir"
+  logfile="$logdir/out.log"
+  run $BATS_TEST_DIRNAME/../gh-pr-approve-and-auto-merge 42 --run --yes --log-file "$logfile"
+  [ "$status" -eq 0 ]
+  grep -q "pr merge 42" "$GH_STUB_LOG"
+  grep -q "Merged #42" "$logfile"
+}


### PR DESCRIPTION
## Summary
- create directory for `LOG_FILE` if it does not exist
- ignore invalid PR numbers that contain non digits
- test invalid PR numbers and log directory creation

## Testing
- `npx bats test`